### PR TITLE
Update progress bar functionality

### DIFF
--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -156,6 +156,7 @@ pub fn app() -> Html {
                                         />
                                     </ybc::Control>
                                 </ybc::Field>
+                                <ybc::Progress value={-1.0} max={100.0} classes={classes!("is-primary")} />
                             </ybc::Tile>
                        </ybc::Tile>
                     </ybc::Tile>

--- a/src/elements/progress.rs
+++ b/src/elements/progress.rs
@@ -21,9 +21,15 @@ pub fn progress(props: &ProgressProps) -> Html {
     let max = props.max.to_string();
     let value = props.value.to_string();
     let value_txt = format!("{}%", value);
-    html! {
-        <progress {class} {max} {value}>
-            {value_txt}
-        </progress>
+    if props.value == -1.0 {
+        html! {
+            <progress {class} {max}/>
+        }
+    } else {
+        html! {
+            <progress {class} {max} {value}>
+                {value_txt}
+            </progress>
+        }
     }
 }


### PR DESCRIPTION
This commit introduces changes to the progress bar functionality in the UI. Now, if a progress bar value is set to -1.0, it will be rendered without a value, indicating an indefinite loading state. It also includes an example displaying this new feature.