### PR TITLE
Add GitHub Pages workflow and enhance documentation configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,10 @@ jobs:
         run: cargo fmt -- --check
       - name: Build
         run: cargo build
+      - name: Install nightly for docs
+        uses: dtolnay/rust-toolchain@nightly
+      - name: Build docs (all features)
+        run: RUSTDOCFLAGS="--cfg docsrs" cargo doc --all-features --no-deps
 
   example_basic:
     name: Example | Basic

--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,46 @@
+name: docs-pages
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Build docs
+        run: RUSTDOCFLAGS="--cfg docsrs" cargo doc --all-features --no-deps
+      - name: Prepare artifact
+        run: |
+          mkdir -p ./public
+          cp -r target/doc/* ./public/
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,14 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup | Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Build | Publish
         run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
@@ -26,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup | Create Release Log
         run: cat CHANGELOG.md | tail -n +7 | head -n 25 > RELEASE_LOG.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Anthony Dodd <dodd.anthonyjosiah@gmail.com>", "Konstantin Pupkov <ko
 edition = "2024"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/goodidea-kp/ybc.git"
+documentation = "https://docs.rs/ybc"
 readme = "README.md"
 categories = ["wasm", "web-programming"]
 keywords = ["wasm", "web", "bulma", "sass", "yew"]
@@ -27,3 +28,5 @@ docinclude = [] # Used only for activating `doc(include="...")` on nightly.
 
 [package.metadata.docs.rs]
 features = ["docinclude"] # Activate `docinclude` during docs.rs build.
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 // TODO: add this back in once it is no longer a land mine:
 //  #![cfg_attr(feature = "docinclude", doc = include_str!("../README.md"))]
 #![recursion_limit = "1024"]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "docinclude", doc = include_str!("../README.md"))]
 
 mod columns;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@
 // TODO: add this back in once it is no longer a land mine:
 //  #![cfg_attr(feature = "docinclude", doc = include_str!("../README.md"))]
 #![recursion_limit = "1024"]
+#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(feature = "docinclude", doc = include_str!("../README.md"))]
 
 mod columns;
 mod common;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! What does it look like to use YBC? The following is a snippet of a component's `view` method
 //! rendering a navbar, a fluid container, and some tiles.
 //!
-//! Please see [this project's README](https://github.com/thedodd/ybc) for the example. **Docs.rs is
+//! Please see [this project's README](https://github.com/goodidea-kp/ybc) for the example. **Docs.rs is
 //! currently (2021.07.26) slightly broken and having trouble including external docs as it has historically.**
 // TODO: add this back in once it is no longer a land mine:
 //  #![cfg_attr(feature = "docinclude", doc = include_str!("../README.md"))]


### PR DESCRIPTION
- Introduce `docs-pages` workflow for publishing documentation to GitHub Pages.
- Update Cargo.toml with `documentation` link and `docs.rs` metadata.
- Enable `doc_cfg` and `doc_auto_cfg` features for enhanced doc generation.
- Adjust CI workflow to build documentation with all features.
- Update `release.yaml` to use the latest checkout and