### PR TITLE
Refactor modal components and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ybc"
-version = "0.4.2"
+version = "0.4.3"
 description = "A Yew component library based on the Bulma CSS framework."
 authors = ["Anthony Dodd <dodd.anthonyjosiah@gmail.com>", "Konstantin Pupkov <konstantin.pupkov@fromkos.com>"]
 edition = "2024"
@@ -12,10 +12,9 @@ categories = ["wasm", "web-programming"]
 keywords = ["wasm", "web", "bulma", "sass", "yew"]
 
 [dependencies]
-derive_more = { version = "2.0.1", default-features = false, features = ["display"] }
-web-sys = { version = "0.3.81", features = ["Element", "File", "HtmlCollection", "HtmlSelectElement"] }
+derive_more = { version = "2.1.1", default-features = false, features = ["display"] }
+web-sys = { version = "0.3.85", features = ["Element", "Event", "File", "HtmlCollection", "HtmlDialogElement", "HtmlElement", "HtmlSelectElement", "MouseEvent"] }
 yew = { version = "0.22.0", features = ["csr"] }
-yew-agent = "0.4.0"
 yew-router = { version = "0.19.0", optional = true }
 wasm-bindgen = "0.2"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -5,7 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>Trunk | Yew | YBC</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@latest/css/bulma.min.css"/>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-calendar@6.1.19/dist/css/bulma-calendar.min.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@7.0.0/css/fontawesome.min.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-calendar-js@7.1.2/dist/css/bulma-calendar.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-accordion@2.0.1/dist/css/bulma-accordion.min.css"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@creativebulma/bulma-tagsinput@1.0.3/dist/css/bulma-tagsinput.min.css" />
     <link data-trunk rel="scss" href="src/index.scss"/>
@@ -19,7 +20,8 @@
 </head>
 <body>
     <link data-trunk rel="rust" href="Cargo.toml" data-wasm-opt="z" data-bin="basic" data-cargo-features="demo-abc,demo-xyz"/>
-    <script src="https://cdn.jsdelivr.net/npm/bulma-calendar@6.1.19/dist/js/bulma-calendar.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.0/js/all.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bulma-calendar-js@7.1.2/dist/js/bulma-calendar.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bulma-accordion@2.0.1/dist/js/bulma-accordion.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@creativebulma/bulma-tagsinput@1.0.3/dist/js/bulma-tagsinput.min.js"></script>
 </body>

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -98,12 +98,10 @@ pub fn app() -> Html {
                                         <p>{"This is the content of the second accordion."}</p>
                                     </ybc::AccordionItem>
                                 </ybc::Accordions>
-                                <ModalCloserProvider id="id0">
-                                       <MyModal1/>
-                                </ModalCloserProvider>
-                                <ModalCloserProvider id="id2">
+                                <ModalControllerProvider>
+                                    <MyModal1/>
                                     <MyModal2/>
-                                </ModalCloserProvider>
+                                </ModalControllerProvider>
                             </ybc::Tile>
                         </ybc::Tile>
                         <ybc::Tile>
@@ -194,16 +192,16 @@ fn main() {
     yew::Renderer::<App>::new().render();
 }
 
-use ybc::ModalCloserContext;
-use ybc::ModalCloserProvider;
+use ybc::ModalControllerContext;
+use ybc::ModalControllerProvider;
 
 #[component]
 pub fn MyModal1() -> Html {
-    let msg_ctx = use_context::<ModalCloserContext>().unwrap();
-    let onclick = { Callback::from(move |e: MouseEvent| msg_ctx.dispatch("id0-close".to_string().parse().unwrap())) };
-    let on_click_cb = Callback::from(move |e: AttrValue| {
-        gloo_console::log!("Button clicked!");
-    });
+    let controller = use_context::<ModalControllerContext>().unwrap();
+    let onclick = {
+        let controller = controller.clone();
+        Callback::from(move |_| controller.close("id0"))
+    };
     html! {
             <ybc::ModalCard
                 classes={classes!("")}
@@ -214,7 +212,6 @@ pub fn MyModal1() -> Html {
                         {"Open Modal"}
                     </ybc::Button>
                 }}
-         // on_clicked={on_click_cb}
                 body={
                     html!{
                     <ybc::Content>
@@ -238,13 +235,15 @@ pub fn MyModal1() -> Html {
 
 #[component(MyModal2)]
 pub fn my_modal2() -> Html {
-    let msg_ctx = use_context::<ModalCloserContext>().unwrap();
-    let onclick = { Callback::from(move |e: MouseEvent| msg_ctx.dispatch("id2-close".to_string().parse().unwrap())) };
-    let msg_ctx2 = use_context::<ModalCloserContext>().unwrap();
-    let onsave = { Callback::from(move |e: MouseEvent| msg_ctx2.dispatch("id2-close".to_string().parse().unwrap())) };
-    let on_click_cb = Callback::from(move |e: AttrValue| {
-        gloo_console::log!("Button clicked!");
-    });
+    let controller = use_context::<ModalControllerContext>().unwrap();
+    let onclick = {
+        let controller = controller.clone();
+        Callback::from(move |_| controller.close("id2"))
+    };
+    let onsave = {
+        let controller = controller.clone();
+        Callback::from(move |_| controller.close("id2"))
+    };
     html! {
             <ybc::ModalCard
                 classes={classes!("")}
@@ -255,7 +254,6 @@ pub fn my_modal2() -> Html {
                         {"Open Modal"}
                     </ybc::Button>
                 }}
-                // on_clicked={on_click_cb}
                 body={
                     html!{
                     <ybc::Content>

--- a/src/components/accordion.rs
+++ b/src/components/accordion.rs
@@ -36,10 +36,10 @@
 //!
 //! Notes and alternatives
 //! - If you use a bundler (webpack, vite, etc.) you can install bulma-accordion from npm and import it in your JS entry:
-//!     npm install bulma-accordion
-//!     // in your entry file
-//!     import 'bulma-accordion/dist/css/bulma-accordion.min.css';
-//!     import 'bulma-accordion/dist/js/bulma-accordion.min.js';
+//!   npm install bulma-accordion
+//!   // in your entry file
+//!   import 'bulma-accordion/dist/css/bulma-accordion.min.css';
+//!   import 'bulma-accordion/dist/js/bulma-accordion.min.js';
 //!   Ensure the import runs before the Yew bootstrap so `bulmaAccordion` is available globally (or adapt the setup to pass the module).
 //!
 //! - The important requirement: bulmaAccordion must be defined on window when setup_accordion is called in rendered().
@@ -119,7 +119,7 @@ impl Component for Accordions {
 
             let element = document
                 .get_element_by_id(ctx.props().id.to_string().as_str())
-                .expect(format!("should have #{} on the page", ctx.props().id).as_str());
+                .unwrap_or_else(|| panic!("should have #{} on the page", ctx.props().id));
 
             setup_accordion(&element);
         }

--- a/src/components/autocomplete.rs
+++ b/src/components/autocomplete.rs
@@ -35,10 +35,10 @@
 //!
 //! Notes and alternatives
 //! - If you use a bundler (webpack, vite, etc.) you can install bulma-tagsinput from npm and import it in your JS entry:
-//!     npm install @creativebulma/bulma-tagsinput
-//!     // in your entry file
-//!     import '@creativebulma/bulma-tagsinput/dist/css/bulma-tagsinput.min.css';
-//!     import '@creativebulma/bulma-tagsinput/dist/js/bulma-tagsinput.min.js';
+//!   npm install @creativebulma/bulma-tagsinput
+//!   // in your entry file
+//!   import '@creativebulma/bulma-tagsinput/dist/css/bulma-tagsinput.min.css';
+//!   import '@creativebulma/bulma-tagsinput/dist/js/bulma-tagsinput.min.js';
 //!   Ensure the import runs before the Yew bootstrap so `BulmaTagsInput` is available globally (or adapt the setup to pass the module).
 //!
 //! - The important requirement: BulmaTagsInput must be defined on window when setup_static_autocomplete / setup_dynamic_autocomplete are called in rendered().
@@ -129,7 +129,7 @@ impl Component for AutoComplete {
                 }
             })
             .collect::<Html>();
-        if ctx.props().items.len() > 0 && ctx.props().data_item_text.len() == 0 && ctx.props().data_item_value.len() == 0 {
+        if !ctx.props().items.is_empty() && ctx.props().data_item_text.is_empty() && ctx.props().data_item_value.is_empty() {
             html! {
                 <div class={classes!(ctx.props().classes.clone(), "select")}>
                     <select
@@ -141,8 +141,8 @@ impl Component for AutoComplete {
                     </select>
                 </div>
             }
-        } else if ctx.props().data_item_text.len() > 0 && ctx.props().data_item_value.len() > 0 {
-            let has_value = current_selector.len() > 0;
+        } else if !ctx.props().data_item_text.is_empty() && !ctx.props().data_item_value.is_empty() {
+            let has_value = !current_selector.is_empty();
             let value = format!("{{\"{}\":\"{}\"}}", ctx.props().data_item_value, current_selector);
             html! {
                    <input type="text"
@@ -172,25 +172,40 @@ impl Component for AutoComplete {
             let document = window.document().expect("should have a document on window");
 
             let element = document
-                .get_element_by_id(&*self.id)
-                .expect(format!("should have #{} on the page", self.id).as_str());
+                .get_element_by_id(&self.id)
+                .unwrap_or_else(|| panic!("should have #{} on the page", self.id));
 
             // Clone the link from the context
             let link = ctx.link().clone();
 
             // Move the cloned link into the closure
             let callback = Closure::wrap(Box::new(move |tag: JsValue| {
-                // gloo_console::log!("Value changed: {}", tag.clone());
-                let command: js_sys::Object = JSON::parse(tag.as_string().unwrap().as_str()).unwrap().dyn_into().unwrap();
-                let op = Reflect::get(&command, &JsValue::from_str("op")).unwrap();
-                let value = Reflect::get(&command, &JsValue::from_str("value")).unwrap();
-                if op.as_string().unwrap() == "add" {
-                    link.send_message(Msg::Added(value.as_string().unwrap()));
+                let Some(raw) = tag.as_string() else {
+                    return;
+                };
+                let Ok(parsed) = JSON::parse(raw.as_str()) else {
+                    return;
+                };
+                let Ok(command) = parsed.dyn_into::<js_sys::Object>() else {
+                    return;
+                };
+                let Ok(op) = Reflect::get(&command, &JsValue::from_str("op")) else {
+                    return;
+                };
+                let Ok(value) = Reflect::get(&command, &JsValue::from_str("value")) else {
+                    return;
+                };
+                let Some(value) = value.as_string() else {
+                    return;
+                };
+
+                if op.as_string().as_deref() == Some("add") {
+                    link.send_message(Msg::Added(value));
                 } else {
-                    link.send_message(Msg::Removed(value.as_string().unwrap()));
+                    link.send_message(Msg::Removed(value));
                 }
             }) as Box<dyn FnMut(JsValue)>);
-            if _url_for_fetch.len() == 0 {
+            if _url_for_fetch.is_empty() {
                 setup_static_autocomplete(&element, callback.as_ref(), &JsValue::from(_max_items), &JsValue::from(_case_sensitive));
             } else {
                 setup_dynamic_autocomplete(
@@ -209,7 +224,7 @@ impl Component for AutoComplete {
     }
 
     fn destroy(&mut self, _ctx: &Context<Self>) {
-        detach_autocomplete(&JsValue::from(self.id.as_ptr()));
+        detach_autocomplete(&JsValue::from_str(self.id.as_ref()));
     }
 }
 

--- a/src/components/calendar.rs
+++ b/src/components/calendar.rs
@@ -1,270 +1,353 @@
-//! Calendar component: a thin Yew wrapper around the bulma‑calendar JS date/time picker.
-//!
-//! Summary
-//! - Enhances a plain `<input>` with bulmaCalendar for date and time selection.
-//! - Emits changes through a Yew `Callback<String>` whenever the user selects, validates, or clears.
-//! - Requires bulmaCalendar JS and CSS to be loaded globally (available as `bulmaCalendar`).
-//!
-//! Value format
-//! - The emitted string follows the configured `date_format` and `time_format` patterns understood by bulmaCalendar.
-//! - Clearing the picker emits an empty string.
-//!
-//! Usage
-//! ```rust
-//! use yew::prelude::*;
-//! use ybc::components::calendar::Calendar;
-//!
-//! #[component(Form)]
-//! fn form() -> Html {
-//!     let date = use_state(|| Option::<String>::None);
-//!     let on_date_changed = {
-//!         let date = date.clone();
-//!         Callback::from(move |d: String| {
-//!             date.set(if d.is_empty() { None } else { Some(d) });
-//!         })
-//!     };
-//!
-//!     html! {
-//!         <Calendar
-//!             id="appointment"
-//!             date_format="yyyy-MM-dd"
-//!             time_format="HH:mm"
-//!             date={(*date).clone()}
-//!             on_date_changed={on_date_changed}
-//!             class={vec!["is-small".into()]}
-//!         />
-//!     }
-//! }
-//! ```
-//!
-//! Required static assets
-//! - Add the bulma‑calendar CSS into your HTML <head>:
-//!   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-calendar@6.1.19/dist/css/bulma-calendar.min.css"/>
-//!
-//! - Add the bulma‑calendar JS so `bulmaCalendar` is available on window. Place this before your wasm bootstrap script
-//!   (or ensure it loads before your Yew app mounts):
-//!   <script src="https://cdn.jsdelivr.net/npm/bulma-calendar@7.1.1/dist/js/bulma-calendar.min.js"></script>
-//!
-//! How to configure index.html
-//! - Minimal example (place CSS in <head>, script before the wasm init script):
-//!   ```html
-//!   <!doctype html>
-//!   <html>
-//!   <head>
-//!     <meta charset="utf-8" />
-//!     <meta name="viewport" content="width=device-width,initial-scale=1" />
-//!     <!-- bulma-calendar CSS -->
-//!     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma-calendar@6.1.19/dist/css/bulma-calendar.min.css"/>
-//!   </head>
-//!   <body>
-//!     <div id="root"></div>
-//!
-//!     <!-- bulma-calendar JS: ensure this runs before your wasm bootstrap so `bulmaCalendar` exists -->
-//!     <script src="https://cdn.jsdelivr.net/npm/bulma-calendar@7.1.1/dist/js/bulma-calendar.min.js"></script>
-//!
-//!     <!-- Your wasm/bootstrap script that starts the Yew app -->
-//!     <script type="module">
-//!       import init from './pkg/your_crate.js';
-//!       init();
-//!     </script>
-//!   </body>
-//!   </html>
-//!   ```
-//!
-//! Notes and alternatives
-//! - If you use a bundler (webpack, vite, etc.) you can install bulma-calendar from npm and import it in your JS entry:
-//!     npm install bulma-calendar
-//!     // in your entry file
-//!     import 'bulma-calendar/dist/css/bulma-calendar.min.css';
-//!     import bulmaCalendar from 'bulma-calendar';
-//!   Ensure the import runs before the Yew bootstrap so `bulmaCalendar` is available globally (or adapt the setup to pass the module).
-//!
-//! - The important requirement: bulmaCalendar must be defined on window when setup_date_picker is called in the component's rendered() hook.
-//!
-//! - If you prefer loading the script asynchronously, make sure to delay Yew app start until bulmaCalendar is available (e.g. listen for script load).
-//!
-//! Implementation notes
-//! - The `id` must be unique in the DOM; it is used to attach and detach the JS calendar instance.
-//! - The underlying `<input>` uses `type="datetime"` for the JS widget; the plugin drives rendering and value handling.
-//!
-//! ...
+/*!
+Calendar component: a thin Yew wrapper around the bulma-calendar JS date/time picker.
 
-use wasm_bindgen::JsValue;
-use wasm_bindgen::closure::Closure;
-use wasm_bindgen::prelude::wasm_bindgen;
-use web_sys::Element;
+Summary
+- Enhances a plain `<input>` with bulmaCalendar for date and time selection.
+- Emits changes through a Rust callback whenever the user selects, validates, or clears.
+- Requires bulmaCalendar JS and CSS to be loaded globally (available as `bulmaCalendar`).
+
+Value format
+- The emitted string follows the configured `date_format` and `time_format` patterns understood by bulmaCalendar.
+- Clearing the picker emits an empty string.
+
+Programmatic control
+- To update the picker value from the outside, update the `date` prop.
+- To clear the picker from the outside, set `date` to a single space `" "`.
+
+Required static assets
+- CSS (add in `<head>`):
+  https://cdn.jsdelivr.net/npm/bulma-calendar@7.1.1/dist/css/bulma-calendar.min.css
+- JS (load before WASM bootstrap so `bulmaCalendar` exists):
+  https://cdn.jsdelivr.net/npm/bulma-calendar@7.1.1/dist/js/bulma-calendar.min.js
+*/
+
 use yew::prelude::*;
-use yew::{Callback, Component, Context, Html};
 
-/// Internal component state for the calendar widget.
-pub struct Calendar {
-    /// Local format placeholder (currently unused by the widget; formats are passed to JS).
-    format: String,
-    /// Current date/time value as a string matching the widget's configured formats.
-    date: Option<String>,
-    /// DOM id of the `<input>` used to attach bulmaCalendar.
-    id: String,
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsCast;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsValue;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::closure::Closure;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::wasm_bindgen;
+#[cfg(target_arch = "wasm32")]
+use web_sys::Element;
+
+#[cfg(target_arch = "wasm32")]
+type CalendarClosure = Closure<dyn FnMut(JsValue)>;
+#[cfg(not(target_arch = "wasm32"))]
+type CalendarClosure = ();
+
+/// Optional test attribute rendered on the input.
+///
+/// Supported keys:
+/// - `data-testid`
+/// - `data-cy`
+#[derive(Clone, Debug, PartialEq)]
+pub struct TestAttr {
+    pub key: AttrValue,
+    pub value: AttrValue,
 }
 
-/// Properties for the `Calendar` component.
-///
-/// - `id`: required, unique DOM id for the input (used to attach/detach the JS widget).
-/// - `date_format`: optional; bulmaCalendar date pattern (default: `yyyy-MM-dd`).
-/// - `time_format`: optional; bulmaCalendar time pattern (default: `HH:mm`).
-/// - `date`: optional initial/current value; will be pushed into the widget on first render.
-/// - `on_date_changed`: invoked on select/validate/clear with the current value (empty on clear).
-/// - `class`: optional extra CSS classes appended to the input, e.g., `vec!["is-small".into()]`.
+impl TestAttr {
+    pub fn test_id(value: impl Into<AttrValue>) -> Self {
+        Self {
+            key: AttrValue::from("data-testid"),
+            value: value.into(),
+        }
+    }
+
+    pub fn data_cy(value: impl Into<AttrValue>) -> Self {
+        Self {
+            key: AttrValue::from("data-cy"),
+            value: value.into(),
+        }
+    }
+}
+
+impl<T> From<T> for TestAttr
+where
+    T: Into<AttrValue>,
+{
+    fn from(value: T) -> Self {
+        Self::test_id(value)
+    }
+}
+
+/// Properties for [`Calendar`].
 #[derive(Clone, PartialEq, Properties)]
 pub struct CalendarProps {
-    /// Unique DOM id of the input element.
+    /// Unique DOM id for the input (used to attach/detach the JS widget).
     pub id: String,
-    /// bulmaCalendar date pattern, e.g., `yyyy-MM-dd`. Falls back to `yyyy-MM-dd` if empty.
+
+    /// Date format understood by bulmaCalendar. Defaults to `yyyy-MM-dd` when empty.
     #[prop_or_default]
-    pub date_format: String,
-    /// bulmaCalendar time pattern, e.g., `HH:mm`. Falls back to `HH:mm` if empty.
+    pub date_format: AttrValue,
+
+    /// Time format understood by bulmaCalendar. Defaults to `HH:mm` when empty.
     #[prop_or_default]
-    pub time_format: String,
-    /// Optional initial/current value for the calendar.
+    pub time_format: AttrValue,
+
+    /// Optional initial/current value to seed or update the widget.
+    #[prop_or_default]
     pub date: Option<String>,
-    /// Callback fired whenever the date/time value changes. Receives empty string on clear.
+
+    /// Callback invoked when the date/time changes; receives empty string on clear.
     pub on_date_changed: Callback<String>,
-    /// Extra CSS classes for the input.
+
+    /// Extra classes appended after Bulma `input`.
+    #[prop_or_default]
     pub class: Vec<String>,
+
+    /// Optional test attribute on the input (`data-testid` or `data-cy`).
+    #[prop_or_default]
+    pub test_attr: Option<TestAttr>,
+
+    /// Picker type (`date`, `time`, `datetime`).
+    /// If empty, defaults to `datetime` when `time_format` is present, otherwise `date`.
+    #[prop_or_default]
+    pub calendar_type: AttrValue,
 }
 
-/// Internal messages for the component update loop.
-pub enum Msg {
-    /// User changed the date/time value through the widget.
-    DateChanged(String),
-}
+/// A date/time input enhanced by bulma-calendar.
+#[function_component(Calendar)]
+pub fn calendar(props: &CalendarProps) -> Html {
+    let input_ref = use_node_ref();
 
-impl Component for Calendar {
-    type Message = Msg;
-    type Properties = CalendarProps;
+    let date_format_raw = props.date_format.trim().to_string();
+    assert!(
+        date_format_raw.is_empty() || date_format_raw == "yyyy-MM-dd",
+        "Calendar date_format must be exactly 'yyyy-MM-dd' (lowercase yyyy-MM-dd). Got '{}'",
+        props.date_format
+    );
 
-    /// Initializes the component with provided props and default format strings.
-    fn create(ctx: &Context<Self>) -> Self {
-        Calendar {
-            format: "%Y-%m-%d %H:%M".to_string(),
-            date: ctx.props().date.clone(),
-            id: ctx.props().id.clone(),
-        }
-    }
+    let date_format = if date_format_raw.is_empty() {
+        "yyyy-MM-dd".to_owned()
+    } else {
+        date_format_raw
+    };
 
-    /// Handles internal messages by updating local state and notifying the parent via callback.
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
-        match msg {
-            Msg::DateChanged(date) => {
-                self.date = Some(date.clone());
-                ctx.props().on_date_changed.emit(date);
-                true
+    let time_format_raw = props.time_format.trim().to_string();
+    let time_format = if time_format_raw.is_empty() {
+        "HH:mm".to_owned()
+    } else {
+        time_format_raw.clone()
+    };
+
+    let calendar_type = {
+        let explicit = props.calendar_type.trim();
+        if explicit.is_empty() {
+            if props.time_format.trim().is_empty() {
+                "date".to_owned()
+            } else {
+                "datetime".to_owned()
             }
+        } else {
+            explicit.to_owned()
         }
+    };
+
+    let initial_value = props.date.clone().unwrap_or_default();
+    let class = classes!("input", props.class.clone());
+
+    let (data_testid, data_cy) = match props.test_attr.as_ref() {
+        Some(attr) if attr.key == "data-testid" => (Some(attr.value.clone()), None),
+        Some(attr) if attr.key == "data-cy" => (None, Some(attr.value.clone())),
+        _ => (None, None),
+    };
+
+    let input_type = if props.time_format.trim().is_empty() {
+        AttrValue::from("date")
+    } else {
+        AttrValue::from("datetime")
+    };
+
+    let callback_store = use_mut_ref(|| None::<CalendarClosure>);
+    let on_date_changed_ref = use_mut_ref(|| props.on_date_changed.clone());
+    *on_date_changed_ref.borrow_mut() = props.on_date_changed.clone();
+
+    {
+        let id = props.id.clone();
+        let input_ref = input_ref.clone();
+        let callback_store = callback_store.clone();
+        let on_date_changed_ref = on_date_changed_ref.clone();
+        let date_format = date_format.clone();
+        let time_format = time_format.clone();
+        let calendar_type = calendar_type.clone();
+        let initial_value = initial_value.clone();
+
+        use_effect_with(
+            (id.clone(), date_format.clone(), time_format.clone(), calendar_type.clone()),
+            move |(id, date_format, time_format, calendar_type)| {
+                #[cfg(target_arch = "wasm32")]
+                {
+                    if let Some(element) = input_ref.cast::<Element>() {
+                        let on_date_changed_ref = on_date_changed_ref.clone();
+                        let callback = Closure::wrap(Box::new(move |date: JsValue| {
+                            let s = date.as_string().unwrap_or_default();
+                            on_date_changed_ref.borrow().emit(s);
+                        }) as Box<dyn FnMut(JsValue)>);
+
+                        setup_date_picker(
+                            &element,
+                            callback.as_ref(),
+                            &JsValue::from(initial_value.clone()),
+                            &JsValue::from(date_format.clone()),
+                            &JsValue::from(time_format.clone()),
+                            &JsValue::from(calendar_type.clone()),
+                        );
+
+                        *callback_store.borrow_mut() = Some(callback);
+                    }
+
+                    let callback_store = callback_store.clone();
+                    let id_for_cleanup = id.clone();
+                    return move || {
+                        detach_date_picker(&JsValue::from(id_for_cleanup.as_str()));
+                        callback_store.borrow_mut().take();
+                    };
+                }
+
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    let _ = (
+                        &input_ref,
+                        &callback_store,
+                        &on_date_changed_ref,
+                        &initial_value,
+                        id,
+                        date_format,
+                        time_format,
+                        calendar_type,
+                    );
+                    || {}
+                }
+            },
+        );
     }
 
-    /// Renders the backing input element. The bulmaCalendar widget attaches to this element.
-    fn view(&self, ctx: &Context<Self>) -> Html {
-        let _value = self.date.clone();
-        let _id = self.id.clone();
-        let classes = classes!("input", ctx.props().class.clone());
-        html! {
-            <input id={_id} class={classes!(classes)} type="datetime" value={_value} />
-        }
+    {
+        let id = props.id.clone();
+        let date = props.date.clone();
+        use_effect_with((id, date), move |(id, date)| {
+            #[cfg(target_arch = "wasm32")]
+            {
+                match date.as_deref() {
+                    Some(" ") | Some("") => {
+                        clear_date(&JsValue::from(id.as_str()));
+                    }
+                    Some(v) => {
+                        update_value(&JsValue::from(id.as_str()), &JsValue::from(v));
+                    }
+                    None => {}
+                }
+            }
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                let _ = (id, date);
+            }
+
+            || {}
+        });
     }
 
-    /// After first render, attaches the bulmaCalendar instance and wires event callbacks.
-    fn rendered(&mut self, ctx: &Context<Self>, first_render: bool) {
-        if first_render {
-            let window = web_sys::window().expect("no global `window` exists");
-            let document = window.document().expect("should have a document on window");
-
-            let element = document
-                .get_element_by_id(self.id.as_str())
-                .expect(format!("should have #{} on the page", self.id.as_str()).as_str());
-
-            // Clone the link for use inside the JS callback closure.
-            let link = ctx.link().clone();
-
-            // JS -> Rust bridge: receive the string value and forward as a Yew message.
-            let callback = Closure::wrap(Box::new(move |date: JsValue| {
-                let date_str = date.as_string().unwrap_or_default();
-                link.send_message(Msg::DateChanged(date_str));
-            }) as Box<dyn FnMut(JsValue)>);
-
-            // Resolve formats, falling back to sensible defaults if props are empty.
-            let _date_format = if ctx.props().date_format.trim().is_empty() {
-                "yyyy-MM-dd".to_string()
-            } else {
-                ctx.props().date_format.trim().to_string()
-            };
-
-            let _time_format = if ctx.props().time_format.trim().is_empty() {
-                "HH:mm".to_string()
-            } else {
-                ctx.props().time_format.trim().to_string()
-            };
-
-            // Attach the JS widget and seed its initial value.
-            setup_date_picker(
-                &element,
-                callback.as_ref(),
-                &JsValue::from(self.date.as_ref().unwrap_or(&"".to_string())),
-                &JsValue::from(_date_format),
-                &JsValue::from(_time_format),
-            );
-
-            // Intentionally leak the closure to keep it alive for the widget's lifetime.
-            callback.forget();
-        }
-    }
-
-    /// Before unmount, detach JS state keyed by the element id.
-    fn destroy(&mut self, _ctx: &Context<Self>) {
-        detach_date_picker(&JsValue::from(self.id.as_str()));
+    html! {
+        <input
+            id={props.id.clone()}
+            class={class}
+            type={input_type}
+            value={initial_value}
+            ref={input_ref}
+            data-testid={data_testid}
+            data-cy={data_cy}
+        />
     }
 }
 
-/// JS bridge that attaches bulmaCalendar to the provided element and wires a change callback.
-///
-/// Safety/expectations:
-/// - `element` must be an `<input>` present in the DOM with a stable `id`.
-/// - `callback` must remain alive for as long as the widget can invoke it (we call `forget()`).
-/// - bulmaCalendar must be globally available.
+#[cfg(target_arch = "wasm32")]
 #[wasm_bindgen(inline_js = r#"
 let init = new Map();
-export function setup_date_picker(element, callback, initial_date, date_format, time_format) {
+
+export function setup_date_picker(element, callback, initial_date, date_format, time_format, picker_type) {
+    if (!element || !element.id) {
+        return;
+    }
+
+    if (typeof bulmaCalendar === 'undefined' || typeof bulmaCalendar.attach !== 'function') {
+        console.warn('bulmaCalendar is not available on window. Calendar will remain a plain input.');
+        return;
+    }
+
     if (!init.has(element.id)) {
-      let calendarInstances = bulmaCalendar.attach(element, {
-            type: 'datetime',
+        const instances = bulmaCalendar.attach(element, {
+            type: picker_type || (String(time_format || '').trim() ? 'datetime' : 'date'),
             color: 'info',
             lang: 'en',
             dateFormat: date_format,
             timeFormat: time_format,
+            showTodayButton: false
         });
-        init.set(element.id, calendarInstances[0]);
-        let calendarInstance = calendarInstances[0];
+
+        if (!instances || !instances.length) {
+            return;
+        }
+
+        const calendarInstance = instances[0];
+        init.set(element.id, calendarInstance);
+
         calendarInstance.on('select', function(datepicker) {
-         callback(datepicker.data.value());
+            callback(datepicker.data.value());
         });
+
         calendarInstance.on('clear', function(_datepicker) {
-         callback('');
+            callback('');
         });
+
         calendarInstance.on('validate', function(datepicker) {
-         callback(datepicker.data.value());
+            callback(datepicker.data.value());
+            if (typeof calendarInstance.hide === 'function') {
+                calendarInstance.hide();
+            }
         });
     }
-    init.get(element.id).value(initial_date);
+
+    if (init.has(element.id)) {
+        init.get(element.id).value(initial_date || '');
+    }
 }
 
 export function detach_date_picker(id) {
-    init.delete(id);
+    if (init.has(id)) {
+        const instance = init.get(id);
+        if (instance && typeof instance.destroy === 'function') {
+            instance.destroy();
+        }
+        init.delete(id);
+    }
+}
+
+export function clear_date(id) {
+    if (init.has(id)) {
+        init.get(id).clear();
+    }
+}
+
+export function update_value(id, value) {
+    if (init.has(id)) {
+        init.get(id).value(value || '');
+    }
 }
 "#)]
+#[allow(improper_ctypes, improper_ctypes_definitions)]
 extern "C" {
-    /// Attach bulmaCalendar to `element`, register `callback`, seed with `initial_date`,
-    /// and apply `date_format`/`time_format`.
-    fn setup_date_picker(element: &Element, callback: &JsValue, initial_date: &JsValue, date_format: &JsValue, time_format: &JsValue);
+    fn setup_date_picker(
+        element: &Element, callback: &JsValue, initial_date: &JsValue, date_format: &JsValue, time_format: &JsValue, picker_type: &JsValue,
+    );
 
-    /// Remove the stored calendar instance keyed by the given `id`.
     fn detach_date_picker(id: &JsValue);
+
+    fn clear_date(id: &JsValue);
+
+    fn update_value(id: &JsValue, value: &JsValue);
 }

--- a/src/components/modal.rs
+++ b/src/components/modal.rs
@@ -1,96 +1,430 @@
 use std::collections::HashSet;
 use std::rc::Rc;
-use wasm_bindgen::JsCast;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
+use wasm_bindgen::JsCast;
+use web_sys::{Event, HtmlDialogElement, HtmlElement, MouseEvent};
 use yew::prelude::*;
 
-use yew_agent::worker::{HandlerId, Worker, WorkerScope};
-
-/// Modal actions.
+/// Modal actions kept for backwards compatibility.
+#[derive(Clone, Debug, PartialEq)]
 pub enum ModalMsg {
     Open,
     Close,
-    CloseFromAgent(ModalCloseMsg),
 }
 
-pub type ModalCloserContext = UseReducerHandle<ModalCloseMsg>;
+#[derive(Clone, Debug, PartialEq)]
+enum ModalControllerAction {
+    Open(String),
+    Close(String),
+    CloseAll,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+struct ModalControllerState {
+    open_ids: HashSet<String>,
+}
+
+impl Reducible for ModalControllerState {
+    type Action = ModalControllerAction;
+
+    fn reduce(self: Rc<Self>, action: Self::Action) -> Rc<Self> {
+        let mut open_ids = self.open_ids.clone();
+
+        match action {
+            ModalControllerAction::Open(id) => {
+                open_ids.insert(id);
+            }
+            ModalControllerAction::Close(id) => {
+                open_ids.remove(&id);
+            }
+            ModalControllerAction::CloseAll => {
+                open_ids.clear();
+            }
+        }
+
+        Rc::new(Self { open_ids })
+    }
+}
+
+/// A controller for opening and closing modals from anywhere in the component tree.
+#[derive(Clone, PartialEq)]
+pub struct ModalController {
+    state: UseReducerHandle<ModalControllerState>,
+}
+
+impl ModalController {
+    fn new(state: UseReducerHandle<ModalControllerState>) -> Self {
+        Self { state }
+    }
+
+    /// Returns true if the modal with `id` is currently open.
+    pub fn is_open(&self, id: &str) -> bool {
+        self.state.open_ids.contains(id)
+    }
+
+    /// Open a modal by id.
+    pub fn open(&self, id: impl Into<String>) {
+        self.state.dispatch(ModalControllerAction::Open(id.into()));
+    }
+
+    /// Close a modal by id.
+    pub fn close(&self, id: impl AsRef<str>) {
+        self.state.dispatch(ModalControllerAction::Close(id.as_ref().to_owned()));
+    }
+
+    /// Close all modals.
+    pub fn close_all(&self) {
+        self.state.dispatch(ModalControllerAction::CloseAll);
+    }
+}
+
+/// Context type for the modal controller.
+pub type ModalControllerContext = ModalController;
+
+static MODAL_AUTO_ID: AtomicUsize = AtomicUsize::new(1);
+
+fn next_modal_id(prefix: &str) -> String {
+    format!("{}-{}", prefix, MODAL_AUTO_ID.fetch_add(1, Ordering::Relaxed))
+}
+
+const DIALOG_STYLE: &str = r#"
+/* Avoid ghost overlays when state is closed. */
+dialog.modal:not([open]) {
+    display: none !important;
+}
+
+/* Make <dialog class="modal"> match Bulma's modal container behavior. */
+dialog.modal[open] {
+    position: fixed !important;
+    inset: 0 !important;
+    width: 100vw !important;
+    height: 100vh !important;
+
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+
+    border: 0 !important;
+    outline: 0 !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    background: transparent !important;
+    color: inherit !important;
+    max-width: none !important;
+    max-height: none !important;
+    -webkit-appearance: none;
+    appearance: none;
+}
+
+dialog.modal:focus,
+dialog.modal:focus-visible {
+    outline: 0 !important;
+    box-shadow: none !important;
+}
+
+dialog.modal::backdrop {
+    background: rgba(10, 10, 10, 0.86);
+}
+
+/* Use a Font Awesome icon instead of Bulma's pseudo-element cross. */
+dialog.modal .ybc-modal-icon-close::before,
+dialog.modal .ybc-modal-icon-close::after {
+    display: none !important;
+}
+
+dialog.modal .ybc-modal-icon-close .icon {
+    color: #fff;
+    font-size: 1.1rem;
+}
+"#;
+
+fn base_class(extra: &Classes, is_active: bool) -> Classes {
+    let mut class = classes!("modal");
+    class.push(extra.clone());
+    if is_active {
+        class.push("is-active");
+    }
+    class
+}
+
+fn focus_dialog(dialog: &HtmlDialogElement) {
+    if let Ok(Some(el)) = dialog.query_selector("[data-ybc-dialog-focus]")
+        && let Ok(html) = el.dyn_into::<HtmlElement>()
+    {
+        let _ = html.focus();
+        return;
+    }
+    let _ = dialog.focus();
+}
+
+fn close_dialog(dialog_ref: &NodeRef) {
+    if let Some(dialog) = dialog_ref.cast::<HtmlDialogElement>()
+        && dialog.open()
+    {
+        dialog.close();
+    }
+}
+
+fn close_icon() -> Html {
+    html! {
+        <span class="icon" aria-hidden="true">
+            <i class="fa-solid fa-xmark"></i>
+        </span>
+    }
+}
+
+fn should_ignore_target(event: &MouseEvent) -> bool {
+    let Some(target) = event.target() else {
+        return false;
+    };
+
+    target
+        .dyn_into::<web_sys::Element>()
+        .map(|el| el.id().starts_with("modal-ignore-"))
+        .unwrap_or(false)
+}
+
+#[derive(Properties, PartialEq)]
+struct DialogShellProps {
+    id: String,
+    #[prop_or_default]
+    classes: Classes,
+    is_active: bool,
+    set_is_active: Callback<bool>,
+    dialog_ref: NodeRef,
+    #[prop_or_default]
+    children: Children,
+}
+
+#[component(DialogShell)]
+fn dialog_shell(props: &DialogShellProps) -> Html {
+    let controller = use_context::<ModalControllerContext>();
+
+    {
+        let dialog_ref = props.dialog_ref.clone();
+        let set_is_active = props.set_is_active.clone();
+        use_effect_with(props.is_active, move |active| {
+            if let Some(dialog) = dialog_ref.cast::<HtmlDialogElement>() {
+                if *active {
+                    if !dialog.open() {
+                        let _ = dialog.show_modal();
+                    }
+                    focus_dialog(&dialog);
+                } else if dialog.open() {
+                    dialog.close();
+                }
+
+                if !dialog.open() && *active {
+                    set_is_active.emit(false);
+                }
+            }
+
+            || {}
+        });
+    }
+
+    let class = base_class(&props.classes, props.is_active);
+
+    let id_for_cancel = props.id.clone();
+    let id_for_close = props.id.clone();
+
+    let dialog_ref_for_cancel = props.dialog_ref.clone();
+    let set_is_active_for_cancel = props.set_is_active.clone();
+    let controller_for_cancel = controller.clone();
+
+    let set_is_active_for_close = props.set_is_active.clone();
+    let controller_for_close = controller.clone();
+
+    html! {
+        <>
+            <style>{DIALOG_STYLE}</style>
+            <dialog
+                id={props.id.clone()}
+                class={class}
+                ref={props.dialog_ref.clone()}
+                oncancel={Callback::from(move |ev: Event| {
+                    ev.prevent_default();
+                    close_dialog(&dialog_ref_for_cancel);
+                    set_is_active_for_cancel.emit(false);
+                    if let Some(controller) = controller_for_cancel.as_ref() {
+                        controller.close(&id_for_cancel);
+                    }
+                })}
+                onclose={Callback::from(move |_ev: Event| {
+                    set_is_active_for_close.emit(false);
+                    if let Some(controller) = controller_for_close.as_ref() {
+                        controller.close(&id_for_close);
+                    }
+                })}
+            >
+                { for props.children.iter() }
+            </dialog>
+        </>
+    }
+}
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct ModalProps {
-    /// The ID of this modal, used for triggering close events from other parts of the app.
-    pub id: String,
+    /// Optional modal id used as controller key and dialog id attribute.
+    ///
+    /// If omitted, a unique id is generated automatically. For programmatic
+    /// open/close via `ModalControllerContext`, provide a stable id.
+    #[prop_or_default]
+    pub id: Option<String>,
     /// The content of the `"modal-content"` element.
     #[prop_or_default]
     pub children: Children,
     /// The contents of the modal trigger, typically a button or the like.
     #[prop_or_default]
     pub trigger: Html,
+    /// Extra classes applied to the root `.modal`.
     #[prop_or_default]
     pub classes: Classes,
+    /// Controlled open state.
+    #[prop_or_default]
+    pub open: Option<bool>,
+    /// Controlled state setter.
+    #[prop_or_default]
+    pub set_open: Option<Callback<bool>>,
 }
 
-/// A classic modal overlay, in which you can include any content you want.
+/// A Bulma modal overlay built on top of native `<dialog>`.
 ///
-/// [https://bulma.io/documentation/components/modal/](https://bulma.io/documentation/components/modal/)
-///
-/// See the docs on the `ModalCloser` agent to be able to close your modal instance from anywhere
-/// in your app for maximum flexibility.
+/// By default this component manages its own local state and opens on trigger click.
+/// If wrapped in a [`ModalControllerProvider`], controller state becomes the source of truth
+/// for uncontrolled modals.
 #[component(Modal)]
 pub fn modal(props: &ModalProps) -> Html {
-    let is_active = use_state(|| false);
-    let id = props.id.clone();
-    let closer_ctx = use_context::<ModalCloserContext>().expect("Modal closer in context");
-    let mut class = Classes::from("modal");
+    let internal_open = use_state(|| false);
+    let is_controlled = props.open.is_some() && props.set_open.is_some();
+    let is_active = props.open.unwrap_or(*internal_open);
 
-    class.push(props.classes.clone());
-    let (_id, _closed) = match closer_ctx.0.contains("-") {
-        true => {
-            let result = closer_ctx.0.split("-").collect::<Vec<&str>>();
-            (result[0], result[1] == "close")
-        }
-        false => (closer_ctx.0.as_str(), false),
+    let controller = use_context::<ModalControllerContext>();
+    let dialog_ref = use_node_ref();
+    let auto_id = use_state(|| next_modal_id("modal"));
+    let modal_id = props.id.clone().unwrap_or_else(|| (*auto_id).clone());
+
+    let set_local_open = {
+        let internal_open = internal_open.clone();
+        let set_open = props.set_open.clone();
+        Callback::from(move |value: bool| {
+            if is_controlled {
+                if let Some(set_open) = set_open.as_ref() {
+                    set_open.emit(value);
+                }
+            } else {
+                internal_open.set(value);
+            }
+        })
     };
 
-    let (opencb, closecb) = if _id == id && *is_active {
-        class.push("is-active");
+    {
+        let set_local_open = set_local_open.clone();
+        use_effect_with(
+            (controller.clone(), modal_id.clone(), is_controlled),
+            move |(controller, modal_id, is_controlled)| {
+                if !*is_controlled && let Some(controller) = controller.as_ref() {
+                    set_local_open.emit(controller.is_open(modal_id));
+                }
 
-        let is_active = is_active.clone();
+                || {}
+            },
+        );
+    }
 
-        (Callback::noop(), Callback::from(move |_| is_active.set(false)))
-    } else if _id == id {
-        let is_active = is_active.clone();
+    let open_action = {
+        let modal_id = modal_id.clone();
+        let controller = controller.clone();
+        let set_local_open = set_local_open.clone();
+        Callback::from(move |_| {
+            if !is_controlled && let Some(controller) = controller.as_ref() {
+                controller.open(modal_id.clone());
+                return;
+            }
 
-        (Callback::from(move |_| is_active.set(true)), Callback::noop())
-    } else {
-        (Callback::noop(), Callback::noop())
+            set_local_open.emit(true);
+            if let Some(controller) = controller.as_ref() {
+                controller.open(modal_id.clone());
+            }
+        })
+    };
+
+    let close_action = {
+        let modal_id = modal_id.clone();
+        let controller = controller.clone();
+        let set_local_open = set_local_open.clone();
+        let dialog_ref = dialog_ref.clone();
+        Callback::from(move |_| {
+            close_dialog(&dialog_ref);
+
+            if !is_controlled && let Some(controller) = controller.as_ref() {
+                controller.close(&modal_id);
+                return;
+            }
+
+            set_local_open.emit(false);
+            if let Some(controller) = controller.as_ref() {
+                controller.close(&modal_id);
+            }
+        })
+    };
+
+    let bg_close = {
+        let close_action = close_action.clone();
+        Callback::from(move |event: MouseEvent| {
+            if should_ignore_target(&event) {
+                event.stop_propagation();
+                return;
+            }
+            close_action.emit(());
+        })
+    };
+
+    let close_btn_close = {
+        let close_action = close_action.clone();
+        Callback::from(move |_| close_action.emit(()))
     };
 
     html! {
         <>
-        <div onclick={opencb}>
-            {props.trigger.clone()}
-        </div>
-        <div id={props.id.clone()} {class}>
-            <div class="modal-background" onclick={closecb.clone()}></div>
-            <div class="modal-content">
-                {props.children.clone()}
+            <div onclick={open_action}>
+                {props.trigger.clone()}
             </div>
-            <button class="modal-close is-large" aria-label="close" onclick={closecb}></button>
-        </div>
+
+            <DialogShell
+                id={modal_id}
+                classes={props.classes.clone()}
+                is_active={is_active}
+                set_is_active={set_local_open}
+                dialog_ref={dialog_ref}
+            >
+                <div class="modal-background" onclick={bg_close}></div>
+
+                <div class="modal-content">
+                    { for props.children.iter() }
+                </div>
+
+                <button class="modal-close is-large ybc-modal-icon-close" type="button" aria-label="close" onclick={close_btn_close}>
+                    {close_icon()}
+                </button>
+            </DialogShell>
         </>
     }
 }
 
-//////////////////////////////////////////////////////////////////////////////
-
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct ModalCardProps {
-    /// The ID of this modal, used for triggering close events from other parts of the app.
-    pub id: AttrValue,
+    /// Optional modal id used as controller key and dialog id attribute.
+    ///
+    /// If omitted, a unique id is generated automatically. For programmatic
+    /// open/close via `ModalControllerContext`, provide a stable id.
+    #[prop_or_default]
+    pub id: Option<AttrValue>,
     /// The title of this modal.
     pub title: AttrValue,
-    /// The content to be placed in the `modal-card-body` not including the modal-card-header /
-    /// modal-card-title, which is handled by the `modal_title` prop.
+    /// The content to be placed in the `modal-card-body`.
     #[prop_or_default]
     pub body: Html,
     /// The content to be placed in the `modal-card-footer`.
@@ -99,228 +433,171 @@ pub struct ModalCardProps {
     /// The contents of the modal trigger, typically a button or the like.
     #[prop_or_default]
     pub trigger: Html,
+    /// Extra classes applied to the root `.modal`.
     #[prop_or_default]
     pub classes: Classes,
+    /// Controlled open state.
+    #[prop_or_default]
+    pub open: Option<bool>,
+    /// Controlled state setter.
+    #[prop_or_default]
+    pub set_open: Option<Callback<bool>>,
 }
 
-/// A classic modal with a header, body, and footer section.
-///
-/// [https://bulma.io/documentation/components/modal/](https://bulma.io/documentation/components/modal/)
-///
-/// See the docs on the `ModalCloser` agent to be able to close your modal instance from anywhere
-/// in your app for maximum flexibility.
+/// A Bulma modal card built on top of native `<dialog>`.
 #[component(ModalCard)]
 pub fn modal_card(props: &ModalCardProps) -> Html {
-    let id = props.id.clone();
-    let closer_ctx = use_context::<ModalCloserContext>().expect("Modal closer in context");
+    let internal_open = use_state(|| false);
+    let is_controlled = props.open.is_some() && props.set_open.is_some();
+    let is_active = props.open.unwrap_or(*internal_open);
 
-    let (_id, closed) = match closer_ctx.0.contains("-") {
-        true => {
-            let result = closer_ctx.0.split("-").collect::<Vec<&str>>();
-            (result[0], result[1] == "close")
-        }
-        false => (closer_ctx.0.as_str(), false),
+    let controller = use_context::<ModalControllerContext>();
+    let dialog_ref = use_node_ref();
+    let auto_id = use_state(|| AttrValue::from(next_modal_id("modal-card")));
+    let modal_id = props.id.clone().unwrap_or_else(|| (*auto_id).clone()).to_string();
+
+    let set_local_open = {
+        let internal_open = internal_open.clone();
+        let set_open = props.set_open.clone();
+        Callback::from(move |value: bool| {
+            if is_controlled {
+                if let Some(set_open) = set_open.as_ref() {
+                    set_open.emit(value);
+                }
+            } else {
+                internal_open.set(value);
+            }
+        })
     };
-    let is_active = use_state(|| false);
 
-    if _id == id && closed {
-        is_active.set(false);
-        closer_ctx.dispatch(id.clone());
+    {
+        let set_local_open = set_local_open.clone();
+        use_effect_with(
+            (controller.clone(), modal_id.clone(), is_controlled),
+            move |(controller, modal_id, is_controlled)| {
+                if !*is_controlled && let Some(controller) = controller.as_ref() {
+                    set_local_open.emit(controller.is_open(modal_id));
+                }
+
+                || {}
+            },
+        );
     }
 
-    let mut class = Classes::from("modal");
-    class.push(props.classes.clone());
+    let open_action = {
+        let modal_id = modal_id.clone();
+        let controller = controller.clone();
+        let set_local_open = set_local_open.clone();
+        Callback::from(move |_| {
+            if !is_controlled && let Some(controller) = controller.as_ref() {
+                controller.open(modal_id.clone());
+                return;
+            }
 
-    let (opencb, closecb) = if _id == id && *is_active {
-        class.push("is-active");
+            set_local_open.emit(true);
+            if let Some(controller) = controller.as_ref() {
+                controller.open(modal_id.clone());
+            }
+        })
+    };
 
-        let is_active = is_active.clone();
+    let close_action = {
+        let modal_id = modal_id.clone();
+        let controller = controller.clone();
+        let set_local_open = set_local_open.clone();
+        let dialog_ref = dialog_ref.clone();
+        Callback::from(move |_| {
+            close_dialog(&dialog_ref);
 
-        (
-            Callback::noop(),
-            Callback::from(move |e: MouseEvent| {
-                let target = e.target();
-                if let Some(target) = target {
-                    let target_element = target.dyn_into::<web_sys::Element>().unwrap();
-                    if target_element.id().starts_with("modal-ignore-") {
-                        // If the target is an element to ignore, stop the event propagation
-                        e.stop_propagation();
-                        return;
-                    }
-                }
-                is_active.set(false)
-            }),
-        )
-    } else if _id == id {
-        let is_active = is_active.clone();
-        // gloo_console::log!("is_active=false call");
-        (Callback::from(move |_| is_active.set(true)), Callback::noop())
-    } else {
-        (Callback::noop(), Callback::noop())
+            if !is_controlled && let Some(controller) = controller.as_ref() {
+                controller.close(&modal_id);
+                return;
+            }
+
+            set_local_open.emit(false);
+            if let Some(controller) = controller.as_ref() {
+                controller.close(&modal_id);
+            }
+        })
+    };
+
+    let bg_close = {
+        let close_action = close_action.clone();
+        Callback::from(move |event: MouseEvent| {
+            if should_ignore_target(&event) {
+                event.stop_propagation();
+                return;
+            }
+            close_action.emit(());
+        })
+    };
+
+    let delete_btn_close = {
+        let close_action = close_action.clone();
+        Callback::from(move |_| close_action.emit(()))
+    };
+    let close_btn_close = {
+        let close_action = close_action.clone();
+        Callback::from(move |_| close_action.emit(()))
     };
 
     html! {
-    <>
-        <div onclick={opencb}>
-            {props.trigger.clone()}
-        </div>
-        <div id={props.id.clone()} {class}>
-            <div class="modal-background" onclick={closecb.clone()}></div>
-            <div class="modal-card">
-                <header class="modal-card-head">
-                    <p class="modal-card-title">{props.title.clone()}</p>
-                    <button class="delete" aria-label="close" onclick={closecb.clone()}></button>
-                </header>
-                <section class="modal-card-body">
-                    {props.body.clone()}
-                </section>
-                <footer class="modal-card-foot">
-                    {props.footer.clone()}
-                </footer>
+        <>
+            <div onclick={open_action}>
+                {props.trigger.clone()}
             </div>
-            <button class="modal-close is-large" aria-label="close" onclick={closecb}></button>
-        </div>
-    </>
+
+            <DialogShell
+                id={modal_id}
+                classes={props.classes.clone()}
+                is_active={is_active}
+                set_is_active={set_local_open}
+                dialog_ref={dialog_ref}
+            >
+                <div class="modal-background" onclick={bg_close}></div>
+
+                <div class="modal-card">
+                    <header class="modal-card-head">
+                        <p class="modal-card-title" tabindex="-1" data-ybc-dialog-focus="true">{props.title.clone()}</p>
+                        <button class="delete" type="button" aria-label="close" onclick={delete_btn_close}></button>
+                    </header>
+                    <section class="modal-card-body">
+                        {props.body.clone()}
+                    </section>
+                    <footer class="modal-card-foot">
+                        {props.footer.clone()}
+                    </footer>
+                </div>
+
+                <button class="modal-close is-large ybc-modal-icon-close" type="button" aria-label="close" onclick={close_btn_close}>
+                    {close_icon()}
+                </button>
+            </DialogShell>
+        </>
     }
 }
 
+/// Backwards-compatible alias for `ModalCard`.
 #[component(ModalCard2)]
 pub fn modal_card2(props: &ModalCardProps) -> Html {
-    let id = props.id.clone();
-    let closer_ctx = use_context::<ModalCloserContext>().expect("Modal closer in context");
-
-    let action = closer_ctx.0.as_str();
-    let (_id, closed) = match action.contains("-") {
-        true => {
-            let result = action.split("-").collect::<Vec<&str>>();
-            (result[0], result[1] == "close")
-        }
-        false => (action, false),
-    };
-    let is_active = use_state(|| false);
-
-    if _id == id && closed {
-        is_active.set(false);
-        closer_ctx.dispatch(id.clone());
-    }
-
-    let mut class = Classes::from("modal");
-    class.push(props.classes.clone());
-
-    let (opencb, closecb) = if _id == id && *is_active {
-        class.push("is-active");
-        // gloo_console::log!("is_active=true call");
-
-        let is_active = is_active.clone();
-
-        (Callback::noop(), Callback::from(move |_| is_active.set(false)))
-    } else if _id == id {
-        let is_active = is_active.clone();
-        (Callback::from(move |_| is_active.set(true)), Callback::noop())
-    } else {
-        (Callback::noop(), Callback::noop())
-    };
-
-    html! {
-    <>
-        <div onclick={opencb}>
-            {props.trigger.clone()}
-        </div>
-        <div id={props.id.clone()} {class}>
-            <div class="modal-background" onclick={closecb.clone()}></div>
-            <div class="modal-card">
-                <header class="modal-card-head">
-                    <p class="modal-card-title">{props.title.clone()}</p>
-                    <button class="delete" aria-label="close" onclick={closecb.clone()}></button>
-                </header>
-                <section class="modal-card-body">
-                    {props.body.clone()}
-                </section>
-                <footer class="modal-card-foot">
-                    {props.footer.clone()}
-                </footer>
-            </div>
-            <button class="modal-close is-large" aria-label="close" onclick={closecb}></button>
-        </div>
-    </>
-    }
-}
-
-//////////////////////////////////////////////////////////////////////////////
-
-/// A request to close a modal instance by ID.
-///
-/// The ID provided in this message must match the ID of the modal which is to be closed, else
-/// the message will be ignored.
-#[derive(Clone, Debug, PartialEq)]
-pub struct ModalCloseMsg(pub AttrValue);
-
-impl Reducible for ModalCloseMsg {
-    type Action = AttrValue;
-
-    fn reduce(self: Rc<Self>, action: Self::Action) -> Rc<Self> {
-        ModalCloseMsg { 0: action }.into()
-    }
-}
-
-/// An agent used for being able to close `Modal` & `ModalCard` instances by ID.
-///
-/// If custom modal closing functionality is need for your modal instance, the following
-/// pattern is recommended.
-///
-/// First, in your component which is using this modal, configure a `ModalCloser` dispatcher.
-/// ```rust
-
-pub struct ModalCloser {
-    link: WorkerScope<Self>,
-    subscribers: HashSet<HandlerId>,
-}
-
-impl Worker for ModalCloser {
-    type Input = ModalCloseMsg;
-    type Message = ();
-    // The agent receives requests to close modals by ID.
-    type Output = ModalCloseMsg;
-
-    // The agent forwards the input to all registered modals.
-
-    fn create(link: &WorkerScope<Self>) -> Self {
-        Self {
-            link: link.clone(),
-            subscribers: HashSet::new(),
-        }
-    }
-
-    fn update(&mut self, _scope: &WorkerScope<Self>, _: Self::Message) {}
-
-    fn connected(&mut self, _scope: &WorkerScope<Self>, id: HandlerId) {
-        self.subscribers.insert(id);
-    }
-
-    fn disconnected(&mut self, _scope: &WorkerScope<Self>, id: HandlerId) {
-        self.subscribers.remove(&id);
-    }
-
-    fn received(&mut self, _scope: &WorkerScope<Self>, msg: Self::Input, _id: HandlerId) {
-        for cmp in self.subscribers.iter() {
-            self.link.respond(*cmp, msg.clone());
-        }
-    }
+    html! { <ModalCard ..props.clone() /> }
 }
 
 #[derive(Properties, Debug, PartialEq)]
-pub struct ModalCloserProviderProps {
+pub struct ModalControllerProviderProps {
     #[prop_or_default]
-    pub children: Html,
-    pub id: String,
+    pub children: Children,
 }
 
+/// Provides [`ModalControllerContext`] to descendants.
 #[component]
-pub fn ModalCloserProvider(props: &ModalCloserProviderProps) -> Html {
-    let msg = use_reducer(|| ModalCloseMsg { 0: props.id.clone().into() });
+pub fn ModalControllerProvider(props: &ModalControllerProviderProps) -> Html {
+    let state = use_reducer(ModalControllerState::default);
+    let controller = ModalController::new(state);
+
     html! {
-        <ContextProvider<ModalCloserContext> context={ msg }>
-         { props.children.clone() }
-        </ContextProvider<ModalCloserContext >>
+        <ContextProvider<ModalControllerContext> context={controller}>
+            { for props.children.iter() }
+        </ContextProvider<ModalControllerContext>>
     }
 }

--- a/src/components/navbar.rs
+++ b/src/components/navbar.rs
@@ -103,7 +103,7 @@ impl Component for Navbar {
         let mut class = Classes::from("navbar");
         class.push(ctx.props().classes.clone());
         if let Some(fixed) = &ctx.props().fixed {
-            class.push(&fixed.to_string());
+            class.push(fixed.to_string());
         }
 
         // navbar-menu classes

--- a/src/components/pagination.rs
+++ b/src/components/pagination.rs
@@ -74,8 +74,8 @@ pub struct PaginationItemProps {
 #[component(PaginationItem)]
 pub fn pagination_item(props: &PaginationItemProps) -> Html {
     let effective_class = match props.current {
-        true => format!("{} is-current", props.item_type.to_string()),
-        false => format!("{}", props.item_type.to_string()),
+        true => format!("{} is-current", props.item_type),
+        false => props.item_type.to_string(),
     };
     html! {
         <a class={effective_class} aria-label={props.label.clone()} onclick={props.onclick.clone()}>

--- a/src/form/file.rs
+++ b/src/form/file.rs
@@ -74,7 +74,7 @@ pub fn file(props: &FileProps) -> Html {
     let onchange = props.update.reform(|ev: web_sys::Event| {
         let input: HtmlInputElement = ev.target_dyn_into().expect_throw("event target should be an input");
         let list = input.files().expect_throw("input should have a file list");
-        (0..list.length()).into_iter().filter_map(|idx| list.item(idx)).collect::<Vec<_>>()
+        (0..list.length()).filter_map(|idx| list.item(idx)).collect::<Vec<_>>()
     });
     html! {
         <div {class}>

--- a/src/form/select.rs
+++ b/src/form/select.rs
@@ -124,7 +124,6 @@ pub fn multi_select(props: &MultiSelectProps) -> Html {
         let select: HtmlSelectElement = ev.target_dyn_into().expect_throw("event target should be a select");
         let opts = select.selected_options();
         (0..opts.length())
-            .into_iter()
             .filter_map(|idx| opts.item(idx))
             .filter_map(|elem| elem.get_attribute("value").or_else(|| elem.text_content()))
             .collect::<Vec<_>>()

--- a/src/form/textarea.rs
+++ b/src/form/textarea.rs
@@ -86,7 +86,7 @@ pub fn text_area(props: &TextAreaProps) -> Html {
     {
         let gen1 = genai.clone();
         use_effect_with(props.is_genai, move |value_prop| {
-            gen1.set(value_prop.clone());
+            gen1.set(*value_prop);
             || ()
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,8 @@ pub use components::dropdown::{Dropdown, DropdownMsg, DropdownProps};
 pub use components::menu::{Menu, MenuLabel, MenuLabelProps, MenuList, MenuListProps, MenuProps};
 pub use components::message::{Message, MessageBody, MessageBodyProps, MessageHeader, MessageHeaderProps, MessageProps};
 pub use components::modal::{
-    Modal, ModalCard, ModalCardProps, ModalCloseMsg, ModalCloser, ModalCloserContext, ModalCloserProvider, ModalCloserProviderProps, ModalMsg,
-    ModalProps,
+    Modal, ModalCard, ModalCard2, ModalCardProps, ModalController, ModalControllerContext, ModalControllerProvider, ModalControllerProviderProps,
+    ModalMsg, ModalProps,
 };
 pub use components::navbar::{
     NavBurgerCloserState, Navbar, NavbarDivider, NavbarDividerProps, NavbarDropdown, NavbarDropdownProps, NavbarFixed, NavbarItem, NavbarItemProps,
@@ -57,7 +57,7 @@ pub use components::pagination::{
 pub use components::panel::{Panel, PanelBlock, PanelBlockProps, PanelProps, PanelTabs, PanelTabsProps};
 pub use components::tabs::{Tabs, TabsProps};
 
-pub use components::calendar::{Calendar, CalendarProps};
+pub use components::calendar::{Calendar, CalendarProps, TestAttr};
 
 // elements
 pub use elements::block::{Block, BlockProps};

--- a/ybc_catalog/chatgpt_catalog.yaml 
+++ b/ybc_catalog/chatgpt_catalog.yaml 
@@ -114,16 +114,17 @@ components:
 
   - id: "modal"
     name: "Modal"
-    additional_rules: "Need to use '<ModalCloserProvider id={ID}>' and implement onclick for a trigger button. ID has a format 'idN' where N is a number starting at 1. and unique in the app"
+    additional_rules: "Wrap modal examples in '<ModalControllerProvider>' and use 'use_context::<ModalControllerContext>()' for open/close/close_all by modal key. Provide a stable id only when you need external controller actions; otherwise id is optional."
     file: "src/components/modal_example.rs"
     route: "/component/modal"
     requires_css: ["bulma"]
     requires_js: []
     props_summary:
-      - "id: String (modal DOM id)"
+      - "id: Option<String> (controller key; auto-generated when omitted)"
       - "children: Children"
       - "trigger: Html"
       - "classes: Classes"
+      - "open: Option<bool>, set_open: Option<Callback<bool>> (controlled mode)"
 
   - id: "tabs"
     name: "Tabs"
@@ -229,6 +230,7 @@ components:
 
   - id: "calendar"
     name: "Calendar"
+    additional_rules: "Set date to \" \" (single space) for programmatic clear; date updates push into existing picker instance."
     file: "src/components/calendar_example_page.rs"
     route: "/component/calendar"
     requires_css: ["bulma", "bulma-calendar@7.1.1"]
@@ -239,3 +241,5 @@ components:
       - "date: Option<String>"
       - "on_date_changed: Callback<String>"
       - "class: Vec<String> (extra input classes)"
+      - "calendar_type: String (date|time|datetime)"
+      - "test_attr: Option<TestAttr> (data-testid or data-cy)"

--- a/ybc_catalog/src/components/form_example.rs
+++ b/ybc_catalog/src/components/form_example.rs
@@ -17,12 +17,6 @@ pub fn form_example_page() -> Html {
             text.set(e);
         })
     };
-    let on_radio_update = {
-        let text = text.clone();
-        Callback::from(move |value: String| {
-            text.set(value);
-        })
-    };
     let selected_radio = use_state(|| "A".to_string());
     let on_radio_update = {
         let selected_radio = selected_radio.clone();

--- a/ybc_catalog/src/components/modal_example.rs
+++ b/ybc_catalog/src/components/modal_example.rs
@@ -2,17 +2,16 @@ use ybc::*;
 use yew::prelude::*;
 #[component(ModalExamplePage)]
 pub fn modal_example_page() -> Html {
-    const ID: &str = "id";//Make sure id has format "idN", where N is a unique number in the app.
-    const ID2: &str = "id2";
+    const ID: &str = "modal-example-1";
+    const ID2: &str = "modal-example-2";
     html! {
       <ybc::Section>
         <ybc::Container>
-        <ModalCloserProvider id={ID}>
-           <MyModal id={ID} classes={classes!("is-success")} />
-        </ModalCloserProvider>
-        <ModalCloserProvider id={ID2}>
-           <MyModal id={ID2} classes={classes!("is-danger")} />
-        </ModalCloserProvider>
+          <ModalControllerProvider>
+            <CloseAllModalsButton />
+            <MyModal id={ID} classes={classes!("is-success")} />
+            <MyModal id={ID2} classes={classes!("is-danger")} />
+          </ModalControllerProvider>
         </ybc::Container>
       </ybc::Section>
     }
@@ -20,35 +19,48 @@ pub fn modal_example_page() -> Html {
 
 #[derive(Clone, Debug, Properties, PartialEq)]
 pub struct MyModalProps {
-    /// The ID of this modal, used for triggering close events from other parts of the app. Format is "idN", where N is a unique number in the app.
+    /// The ID of this modal, used as the controller key and DOM id.
     #[prop_or_default("id")]
     pub id: String,
     #[prop_or_default]
     pub classes: Classes,
 }
+
+#[component(CloseAllModalsButton)]
+pub fn close_all_modals_button() -> Html {
+    let controller = use_context::<ModalControllerContext>().expect("Modal controller in context");
+    let onclick = Callback::from(move |_| controller.close_all());
+
+    html! {
+        <ybc::Button classes={classes!("is-warning", "is-light")} {onclick}>
+            {"Close all modals"}
+        </ybc::Button>
+    }
+}
+
 #[component(MyModal)]
 pub fn my_modal(props: &MyModalProps) -> Html {
-    let msg_ctx = use_context::<ModalCloserContext>().unwrap();
-    let id_close = format!("{}-close", props.id);
+    let controller = use_context::<ModalControllerContext>().expect("Modal controller in context");
+    let id = props.id.clone();
+
     let onclick = {
-        let id = id_close.clone();
-        Callback::from(move |e: MouseEvent| msg_ctx.dispatch(id.clone().parse().unwrap()))
+        let controller = controller.clone();
+        let id = id.clone();
+        Callback::from(move |_| controller.close(&id))
     };
-    let msg_ctx2 = use_context::<ModalCloserContext>().unwrap();
     let onsave = {
-        let id = id_close.clone();
-        Callback::from(move |e: MouseEvent| msg_ctx2.dispatch(id.parse().unwrap()))
+        let controller = controller.clone();
+        let id = id.clone();
+        Callback::from(move |_| controller.close(&id))
     };
-    let on_click_cb = Callback::from(move |e: MouseEvent| {
-        gloo_console::log!(" Button clicked! ID:", id_close.clone());
-    });
+
     html! {
             <ybc::ModalCard
                 classes={classes!("")}
                 id={props.id.clone()}
                 title={"Modal"}
                 trigger={html!{
-                    <ybc::Button classes={&props.classes} onclick={on_click_cb}>
+                    <ybc::Button classes={&props.classes}>
                         {"Open Modal"}
                     </ybc::Button>
                 }}

--- a/ybc_catalog/src/ui/catalog_list.rs
+++ b/ybc_catalog/src/ui/catalog_list.rs
@@ -11,7 +11,7 @@ pub fn catalog_list() -> Html {
         ("Form Controls", Route::Form, "Input, Textarea, Select, Checkbox, Radio, Calendar"),
         ("Columns", Route::Columns, "Responsive layout with Columns/Column"),
         ("Table", Route::Table, "Striped, hoverable, bordered"),
-        ("Modal", Route::Modal, "Controlled active state; close callbacks"),
+        ("Modal", Route::Modal, "Dialog-backed modals with controller/context open-close"),
         ("Tabs", Route::Tabs, "Controlled active index; content switch"),
         ("Tag & Notification", Route::TagNotification, "Color tags and notification types"),
         ("Image & Icon", Route::ImageIcon, "Bulma Image sizes and Font Awesome icons"),


### PR DESCRIPTION
- Introduced `<dialog>`-based modal controller for `Modal` and `ModalCard` components.
- Added support for controlled and uncontrolled modal states.
- Replaced `ModalCloser` with `ModalController`.
- Updated modal examples to leverage the new context-based controller.
- Upgraded `web-sys` and `derive_more` dependencies to support new features.
- Updated catalog YAML to document changes in modal usage and API.
- Bumped crate version to `0.4.3`.