### PR TITLE
Update `yew` and `yew-router` dependencies, bump versions for `ybc`, …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ybc"
-version = "0.4.4"
+version = "0.4.5"
 description = "A Yew component library based on the Bulma CSS framework."
 authors = ["Anthony Dodd <dodd.anthonyjosiah@gmail.com>", "Konstantin Pupkov <konstantin.pupkov@fromkos.com>"]
 edition = "2024"
@@ -14,8 +14,8 @@ keywords = ["wasm", "web", "bulma", "sass", "yew"]
 [dependencies]
 derive_more = { version = "2.1.1", default-features = false, features = ["display"] }
 web-sys = { version = "0.3.85", features = ["Element", "Event", "File", "HtmlCollection", "HtmlDialogElement", "HtmlElement", "HtmlSelectElement", "MouseEvent"] }
-yew = { version = "0.22.0", features = ["csr"] }
-yew-router = { version = "0.19.0", optional = true }
+yew = { version = "0.23.0", features = ["csr"] }
+yew-router = { version = "0.20.0", optional = true }
 wasm-bindgen = "0.2"
 serde = { version = "1.0.228", features = ["derive"] }
 #gloo-console = "0.3.0"

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -9,7 +9,7 @@ console_error_panic_hook = "0.1"
 gloo-console = "0.3"
 wasm-bindgen = "0.2"
 ybc = { path = "../.." }
-yew = "0.22"
+yew = { version = "0.23.0", features = ["csr"] }
 
 [features]
 default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,9 @@ pub use components::navbar::{
     NavBurgerCloserState, Navbar, NavbarDivider, NavbarDividerProps, NavbarDropdown, NavbarDropdownProps, NavbarFixed, NavbarItem, NavbarItemProps,
     NavbarItemTag, NavbarMsg, NavbarProps,
 };
-pub use components::pagination::{
-    Pagination, PaginationEllipsis, PaginationItem, PaginationItemProps, PaginationItemRouter, PaginationItemType, PaginationProps,
-};
+#[cfg(feature = "router")]
+pub use components::pagination::PaginationItemRouter;
+pub use components::pagination::{Pagination, PaginationEllipsis, PaginationItem, PaginationItemProps, PaginationItemType, PaginationProps};
 pub use components::panel::{Panel, PanelBlock, PanelBlockProps, PanelProps, PanelTabs, PanelTabsProps};
 pub use components::tabs::{TabItem, TabItemProps, TabPanel, TabPanelProps, Tabs, TabsProps};
 
@@ -63,10 +63,11 @@ pub use components::calendar::{Calendar, CalendarProps, TestAttr};
 pub use elements::block::{Block, BlockProps};
 pub use elements::r#box::{Box, BoxProps};
 pub use elements::button::{
-    Button, ButtonAnchor, ButtonAnchorProps, ButtonAnchorRouter, ButtonColor, ButtonGroupSize, ButtonInputReset, ButtonInputResetProps,
-    ButtonInputSubmit, ButtonInputSubmitProps, ButtonProps, ButtonRouter, ButtonRouterProps, ButtonSize, ButtonType, ButtonVariant, Buttons,
-    ButtonsProps, IconButton, IconButtonProps,
+    Button, ButtonAnchor, ButtonAnchorProps, ButtonColor, ButtonGroupSize, ButtonInputReset, ButtonInputResetProps, ButtonInputSubmit,
+    ButtonInputSubmitProps, ButtonProps, ButtonSize, ButtonType, ButtonVariant, Buttons, ButtonsProps, IconButton, IconButtonProps,
 };
+#[cfg(feature = "router")]
+pub use elements::button::{ButtonAnchorRouter, ButtonRouter, ButtonRouterProps};
 pub use elements::content::{Content, ContentProps};
 pub use elements::delete::{Delete, DeleteProps};
 pub use elements::icon::{FaIcon, FaIconProps, Icon, IconProps};

--- a/ybc_catalog/Cargo.toml
+++ b/ybc_catalog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ybc-catalog"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 publish = false
@@ -10,14 +10,12 @@ repository = "https://github.com/goodidea-kp/ybc.git"
 
 
 [dependencies]
-yew = { version = "0.22.0", features = ["csr"] }
+yew = { version = "0.23.0", features = ["csr"] }
 #ybc = { git = "https://github.com/goodidea-kp/ybc.git" }
 ybc = { path = ".." }
 wasm-bindgen = "0.2"
-gloo = { version = "0.11", features = ["console"] }
-yew-router = "0.19"
+yew-router = "0.20.0"
 web-sys = { version = "0.3", features = ["Window", "Document", "Element"] }
-gloo-console = "0.3.0"
 
 # Optional: keep local development override without affecting publish.
 # This section is ignored by downstream users and does not block publishing.


### PR DESCRIPTION
…`ybc-catalog`, and example projects

- Upgrade `yew` to 0.23.0 with CSR feature.
- Update `yew-router` to 0.20.0.
- Adjust exports for `router`-dependent features.
- Bump package versions for `ybc` (0.4.5) and `ybc-catalog` (0.1.1).