### PR TITLE
Fix ModalCard title/body overflowing the viewport for long content

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ybc"
-version = "0.4.5"
+version = "0.4.6"
 description = "A Yew component library based on the Bulma CSS framework."
 authors = ["Anthony Dodd <dodd.anthonyjosiah@gmail.com>", "Konstantin Pupkov <konstantin.pupkov@fromkos.com>"]
 edition = "2024"

--- a/src/components/modal.rs
+++ b/src/components/modal.rs
@@ -158,6 +158,23 @@ dialog.modal::backdrop {
     background: rgba(10, 10, 10, 0.86);
 }
 
+/* Bulma's .modal-card-title has flex-shrink:0 with no min-width override,
+   so a long unbroken string (a hostname, an ARN) in the title forces
+   modal-card-head wider than the card instead of wrapping, pushing the
+   whole dialog off-screen once centered. */
+.modal-card-head,
+.modal-card-title {
+    min-width: 0;
+}
+
+.modal-card-title {
+    overflow-wrap: anywhere;
+}
+
+.modal-card-body {
+    overflow-x: auto;
+}
+
 "#;
 
 fn base_class(extra: &Classes, is_active: bool) -> Classes {


### PR DESCRIPTION
## Summary
- Bulma's `.modal-card-title` has `flex-shrink:0` with no `min-width` override, so a long unbroken string in the title (a hostname, an ARN) forces `modal-card-head` wider than the card instead of wrapping.
- Once that happens, Bulma's centering pushes the whole `ModalCard` off-screen on both edges instead of the title wrapping — reproduced via ui-client's Install-certificate modal (`"Install SERVER certificate for pg-mtls-test.bastion.internal"`).
- Adds `min-width: 0` on `.modal-card-head`/`.modal-card-title`, `overflow-wrap: anywhere` on the title, and `overflow-x: auto` on `.modal-card-body` as a backstop for wide table content — all folded into the existing per-instance `DIALOG_STYLE` block that `ModalCard` already injects for other Bulma/`<dialog>` fixes.

## Test plan
- [x] `cargo check --lib` passes
- [x] Verified end-to-end against a consumer (ui-client) via a local path patch: rebuilt the WASM bundle, confirmed the new CSS is present in the compiled `.wasm` output, and confirmed the local dev server serves it